### PR TITLE
feat: add DefaultAppWithTimeout with configurable server and middleware timeouts

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -11,8 +11,16 @@ type MetricsConfig struct {
 	Port    int    `env:"METRICS_PORT" env-default:"9100"`
 }
 
+type TimeoutConfig struct {
+	ReadTimeout    int `env:"SERVER_READ_TIMEOUT" env-default:"30"`
+	WriteTimeout   int `env:"SERVER_WRITE_TIMEOUT" env-default:"30"`
+	IdleTimeout    int `env:"SERVER_IDLE_TIMEOUT" env-default:"120"`
+	HandlerTimeout int `env:"SERVER_HANDLER_TIMEOUT" env-default:"25"`
+}
+
 type AppConfig struct {
 	Server
-	Metrics MetricsConfig
-	AppEnv  string `env:"APP_ENV" env-default:"dev"` // "dev", "prodction"
+	Metrics  MetricsConfig
+	Timeouts TimeoutConfig
+	AppEnv   string `env:"APP_ENV" env-default:"dev"` // "dev", "prodction"
 }

--- a/cmd/app-with-timeout/main.go
+++ b/cmd/app-with-timeout/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/tendant/chi-demo/app"
+)
+
+func main() {
+	server := app.DefaultAppWithTimeout()
+	app.RoutesDefault(server.R)
+	app.RoutesVersion(server.R)
+	app.RoutesHealthz(server.R)
+	app.RoutesHealthzReady(server.R)
+	server.RunWithTimeout()
+}


### PR DESCRIPTION
This PR adds timeout support for chi-demo applications through new `DefaultAppWithTimeout()` function and `RunWithTimeout()` method.                                                                             │
│                                                                                                                                                                                                                    │
│   ## Changes                                                                                                                                                                                                       │
│   - **TimeoutConfig**: New configuration struct supporting environment-based timeout settings                                                                                                                      │
│   - **DefaultAppWithTimeout()**: New function that creates an app with timeout middleware enabled                                                                                                                  │
│   - **RunWithTimeout()**: New method that runs HTTP server with configured timeouts                                                                                                                                │
│   - **Example Application**: Demonstrates usage in `cmd/app-with-timeout/`                                                                                                                                         │
│   - **Bug Fix**: Remove duplicate `WithMetrics(true)` call in `DefaultApp()`                                                                                                                                       │
│                                                                                                                                                                                                                    │
│   ## Configuration                                                                                                                                                                                                 │
│   All timeouts configurable via environment variables with sensible defaults:                                                                                                                                      │
│   - `SERVER_READ_TIMEOUT=30` (seconds)                                                                                                                                                                             │
│   - `SERVER_WRITE_TIMEOUT=30` (seconds)                                                                                                                                                                            │
│   - `SERVER_IDLE_TIMEOUT=120` (seconds)                                                                                                                                                                            │
│   - `SERVER_HANDLER_TIMEOUT=25` (seconds)                                                                                                                                                                          │
│                                                                                                                                                                                                                    │
│   ## Backward Compatibility                                                                                                                                                                                        │
│   ✅ **No breaking changes** - `DefaultApp()` and `Run()` remain unchanged                                                                                                                                          │
│   ✅ **Opt-in feature** - Users choose when to adopt timeouts                                                                                                                                                       │
│   ✅ **Clean migration path** - Easy switch from `DefaultApp()` to `DefaultAppWithTimeout()`                                                                                                                        │
│                                                                                                                                                                                                                    │
│   ## Testing                                                                                                                                                                                                       │
│   - ✅ Builds successfully                                                                                                                                                                                          │
│   - ✅ Example application works correctly                                                                                                                                                                          │
│   - ✅ No test failures                                                                                                                                                                                             │
│                                                                                                                                                                                                                    │
│   🤖 Generated with [Claude Code](https://claude.ai/code)